### PR TITLE
don't display tooltip if not set

### DIFF
--- a/LibAddonMenuOrderListBox/LAM2_orderlistbox_widget.lua
+++ b/LibAddonMenuOrderListBox/LAM2_orderlistbox_widget.lua
@@ -728,7 +728,7 @@ function OrderListBox:RowSetupFunction(rowControl, data, scrollList)
         if self.draggingEntryId == nil and not isMouseDown then
             setMouseCursor(mouseCursorHand)
         end
-        if not isMouseDown then
+        if not isMouseDown and tooltip then
             ZO_Tooltips_ShowTextTooltip(p_rowControl, LEFT, tooltip)
         end
     end)


### PR DESCRIPTION
Tooltip is an optional value but control still attempts to display it even if not set, resulting in an empty tooltip